### PR TITLE
DNM - Migrate ec2_vpc_egress_igw* modules and tests

### DIFF
--- a/changelogs/fragments/20240919-fix_sanity.yml
+++ b/changelogs/fragments/20240919-fix_sanity.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Fix sanity errors happening with the ansible devel branch (e.g., unreachable code, using variable before assignment)."

--- a/changelogs/fragments/20240920-refactor-autoscaling_instance_refresh-modules.yml
+++ b/changelogs/fragments/20240920-refactor-autoscaling_instance_refresh-modules.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - autoscaling_instance_refresh - Fix typo in module ``exit_json`` (https://github.com/ansible-collections/community.aws/issues/2019).
+minor_changes:
+  - autoscaling_instance_refresh - refactor module to use shared code from ``ansible_collections.amazon.aws.plugins.module_utils.autoscaling`` and add type hinting (https://github.com/ansible-collections/community.aws/pull/2150).
+  - autoscaling_instance_refresh - Add support for ``skip_matching`` and ``max_healthy_percentage`` in ``preference`` (https://github.com/ansible-collections/community.aws/pull/2150).
+  - autoscaling_instance_refresh_info - refactor module to use shared code from ``ansible_collections.amazon.aws.plugins.module_utils.autoscaling`` and add type hinting (https://github.com/ansible-collections/community.aws/pull/2150).

--- a/changelogs/fragments/20240923-refactor-ec2_vpc_egress_igw-modules.yml
+++ b/changelogs/fragments/20240923-refactor-ec2_vpc_egress_igw-modules.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ec2_vpc_egress_igw - Refactor module to use shared code from ``amazon.aws.plugins.module_utils.ec2`` util (https://github.com/ansible-collections/community.aws/pull/2152).
+  - ec2_vpc_egress_igw - Add the possibility to update/add tags on Egress only internet gateway (https://github.com/ansible-collections/community.aws/pull/2152).

--- a/changelogs/fragments/20240924-create-ignore-2.19.yml
+++ b/changelogs/fragments/20240924-create-ignore-2.19.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Add tests/sanity/ignore-2.19.txt file."

--- a/changelogs/fragments/2139-elb_classic_lb_info-refactor-module.yml
+++ b/changelogs/fragments/2139-elb_classic_lb_info-refactor-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- elb_classic_lb_info - Refactor elb_classic_lb_info module (https://github.com/ansible-collections/community.aws/pull/2139).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -114,7 +114,6 @@ action_groups:
     - ec2_transit_gateway_info
     - ec2_transit_gateway_vpc_attachment
     - ec2_transit_gateway_vpc_attachment_info
-    - ec2_vpc_egress_igw
     - ec2_vpc_nacl
     - ec2_vpc_nacl_info
     - ec2_vpc_peer
@@ -520,6 +519,8 @@ plugin_routing:
       redirect: amazon.aws.s3_bucket_info
     sts_assume_role:
       redirect: amazon.aws.sts_assume_role
+    ec2_vpc_egress_igw:
+      redirect: amazon.aws.ec2_vpc_egress_igw
   module_utils:
     route53:
       redirect: amazon.aws.route53

--- a/plugins/modules/autoscaling_instance_refresh.py
+++ b/plugins/modules/autoscaling_instance_refresh.py
@@ -12,7 +12,7 @@ short_description: Start or cancel an EC2 Auto Scaling Group (ASG) instance refr
 description:
   - Start or cancel an EC2 Auto Scaling Group instance refresh in AWS.
   - Can be used with M(community.aws.autoscaling_instance_refresh_info) to track the subsequent progress.
-  - Prior to release 5.0.0 this module was called C(community.aws.ec2_asg_instance_refresh).
+  - Prior to release 5.0.0 this module was called M(community.aws.ec2_asg_instance_refresh).
     The usage did not change.
 author:
   - "Dan Khersonsky (@danquixote)"
@@ -30,7 +30,7 @@ options:
     required: true
   strategy:
     description:
-      - The strategy to use for the instance refresh. The only valid value is C(Rolling).
+      - The strategy to use for the instance refresh. The only valid value is V(Rolling).
       - A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.
       - A rolling update can fail due to failed health checks or if instances are on standby or are protected from scale in.
       - If the rolling update process fails, any instances that were already replaced are not rolled back to their previous configuration.
@@ -40,15 +40,16 @@ options:
     description:
       - Set of preferences associated with the instance refresh request.
       - If not provided, the default values are used.
-      - For I(min_healthy_percentage), the default value is C(90).
-      - For I(instance_warmup), the default is to use the value specified for the health check grace period for the Auto Scaling group.
-      - Can not be specified when I(state) is set to 'cancelled'.
+      - For O(preferences.min_healthy_percentage), the default value is V(90).
+      - For O(preferences.instance_warmup), the default is to use the value specified for the health check grace period for the Auto Scaling group.
+      - Can not be specified when O(state=cancelled).
     required: false
     suboptions:
       min_healthy_percentage:
         description:
           - Total percent of capacity in ASG that must remain healthy during instance refresh to allow operation to continue.
           - It is rounded up to the nearest integer.
+          - Value range is V(0) to V(100).
         type: int
         default: 90
       instance_warmup:
@@ -57,6 +58,21 @@ options:
           - During this time, Amazon EC2 Auto Scaling does not immediately move on to the next replacement.
           - The default is to use the value for the health check grace period defined for the group.
         type: int
+      skip_matching:
+        description:
+          - Indicates whether skip matching is enabled.
+          - If enabled V(true), then Amazon EC2 Auto Scaling skips replacing instances that match the desired configuration.
+        type: bool
+        version_added: 9.0.0
+      max_healthy_percentage:
+        description:
+          - Specifies the maximum percentage of the group that can be in service and healthy, or pending,
+            to support your workload when replacing instances.
+          - The value is expressed as a percentage of the desired capacity of the Auto Scaling group.
+          - Value range is V(100) to V(200).
+          - When specified, you must also specify O(preferences.min_healthy_percentage), and the difference between them cannot be greater than V(100).
+        type: int
+        version_added: 9.0.0
     type: dict
 extends_documentation_fragment:
   - amazon.aws.common.modules
@@ -84,98 +100,117 @@ EXAMPLES = r"""
     preferences:
       min_healthy_percentage: 91
       instance_warmup: 60
+      skip_matching: true
 """
 
 RETURN = r"""
----
-instance_refresh_id:
-    description: instance refresh id
-    returned: success
-    type: str
-    sample: "08b91cf7-8fa6-48af-b6a6-d227f40f1b9b"
-auto_scaling_group_name:
-    description: Name of autoscaling group
-    returned: success
-    type: str
-    sample: "public-webapp-production-1"
-status:
-    description:
-      -  The current state of the group when DeleteAutoScalingGroup is in progress.
-      -  The following are the possible statuses
-      -    Pending --  The request was created, but the operation has not started.
-      -    InProgress --  The operation is in progress.
-      -    Successful --  The operation completed successfully.
-      -    Failed --  The operation failed to complete. You can troubleshoot using the status reason and the scaling activities.
-      -    Cancelling --
-      -        An ongoing operation is being cancelled.
-      -        Cancellation does not roll back any replacements that have already been completed,
-      -        but it prevents new replacements from being started.
-      -    Cancelled --  The operation is cancelled.
-    returned: success
-    type: str
-    sample: "Pending"
-start_time:
-    description: The date and time this ASG was created, in ISO 8601 format.
-    returned: success
-    type: str
-    sample: "2015-11-25T00:05:36.309Z"
-end_time:
-    description: The date and time this ASG was created, in ISO 8601 format.
-    returned: success
-    type: str
-    sample: "2015-11-25T00:05:36.309Z"
-percentage_complete:
-    description: the % of completeness
-    returned: success
-    type: int
-    sample: 100
-instances_to_update:
-    description: num. of instance to update
-    returned: success
-    type: int
-    sample: 5
+instance_refreshes:
+    description: Details of the instance refreshes for the Auto Scaling group.
+    returned: always
+    type: complex
+    contains:
+        instance_refresh_id:
+            description: Instance refresh id.
+            returned: success
+            type: str
+            sample: "08b91cf7-8fa6-48af-b6a6-d227f40f1b9b"
+        auto_scaling_group_name:
+            description: Name of autoscaling group.
+            returned: success
+            type: str
+            sample: "public-webapp-production-1"
+        status:
+            description:
+              - The current state of the group when DeleteAutoScalingGroup is in progress.
+              - The following are the possible statuses
+              - Pending - The request was created, but the operation has not started.
+              - InProgress - The operation is in progress.
+              - Successful - The operation completed successfully.
+              - Failed - The operation failed to complete.
+                You can troubleshoot using the status reason and the scaling activities.
+              - Cancelling - An ongoing operation is being cancelled.
+                Cancellation does not roll back any replacements that have already been
+                completed, but it prevents new replacements from being started.
+              - Cancelled - The operation is cancelled.
+            returned: success
+            type: str
+            sample: "Pending"
+        preferences:
+            description: The preferences for an instance refresh.
+            returned: always
+            type: dict
+            sample: {
+                'AlarmSpecification': {
+                    'Alarms': [
+                        'my-alarm',
+                    ],
+                },
+                'AutoRollback': True,
+                'InstanceWarmup': 200,
+                'MinHealthyPercentage': 90,
+                'ScaleInProtectedInstances': 'Ignore',
+                'SkipMatching': False,
+                'StandbyInstances': 'Ignore',
+            }
+        start_time:
+            description: The date and time this ASG was created, in ISO 8601 format.
+            returned: success
+            type: str
+            sample: "2015-11-25T00:05:36.309Z"
+        end_time:
+            description: The date and time this ASG was created, in ISO 8601 format.
+            returned: success
+            type: str
+            sample: "2015-11-25T00:05:36.309Z"
+        percentage_complete:
+            description: the % of completeness.
+            returned: success
+            type: int
+            sample: 100
+        instances_to_update:
+            description: number of instances to update.
+            returned: success
+            type: int
+            sample: 5
 """
 
-try:
-    from botocore.exceptions import BotoCoreError
-    from botocore.exceptions import ClientError
-except ImportError:
-    pass  # caught by AnsibleAWSModule
+from typing import Dict
+from typing import Optional
+from typing import Union
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.autoscaling import AnsibleAutoScalingError
+from ansible_collections.amazon.aws.plugins.module_utils.autoscaling import cancel_instance_refresh
+from ansible_collections.amazon.aws.plugins.module_utils.autoscaling import describe_instance_refreshes
+from ansible_collections.amazon.aws.plugins.module_utils.autoscaling import start_instance_refresh
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 
 
-def start_or_cancel_instance_refresh(conn, module):
+def validate_healthy_percentage(preferences: Dict[str, Union[bool, int]]) -> Optional[str]:
+    min_healthy_percentage = preferences.get("min_healthy_percentage")
+    max_healthy_percentage = preferences.get("max_healthy_percentage")
+
+    if min_healthy_percentage is not None and (min_healthy_percentage < 0 or min_healthy_percentage > 100):
+        return "The value range for the min_healthy_percentage is 0 to 100."
+    if max_healthy_percentage is not None:
+        if max_healthy_percentage < 100 or max_healthy_percentage > 200:
+            return "The value range for the max_healthy_percentage is 100 to 200."
+        if min_healthy_percentage is None:
+            return "You must also specify min_healthy_percentage when max_healthy_percentage is specified."
+        if (max_healthy_percentage - min_healthy_percentage) > 100:
+            return "The difference between the max_healthy_percentage and min_healthy_percentage cannot be greater than 100."
+    return None
+
+
+def start_or_cancel_instance_refresh(conn, module: AnsibleAWSModule) -> None:
     """
     Args:
         conn (boto3.AutoScaling.Client): Valid Boto3 ASG client.
         module: AnsibleAWSModule object
-
-    Returns:
-        {
-            "instance_refreshes": [
-                    {
-                        'auto_scaling_group_name': 'ansible-test-hermes-63642726-asg',
-                        'instance_refresh_id': '6507a3e5-4950-4503-8978-e9f2636efc09',
-                        'instances_to_update': 1,
-                        'percentage_complete': 0,
-                        "preferences": {
-                            "instance_warmup": 60,
-                            "min_healthy_percentage": 90,
-                            "skip_matching": false
-                        },
-                        'start_time': '2021-02-04T03:39:40+00:00',
-                        'status': 'Cancelling',
-                        'status_reason': 'Replacing instances before cancelling.',
-                    }
-              ]
-        }
     """
 
     asg_state = module.params.get("state")
@@ -183,24 +218,25 @@ def start_or_cancel_instance_refresh(conn, module):
     preferences = module.params.get("preferences")
 
     args = {}
-    args["AutoScalingGroupName"] = asg_name
     if asg_state == "started":
         args["Strategy"] = module.params.get("strategy")
     if preferences:
         if asg_state == "cancelled":
             module.fail_json(msg="can not pass preferences dict when canceling a refresh")
-        _prefs = scrub_none_parameters(preferences)
-        args["Preferences"] = snake_dict_to_camel_dict(_prefs, capitalize_first=True)
+        error = validate_healthy_percentage(preferences)
+        if error:
+            module.fail_json(msg=error)
+        args["Preferences"] = snake_dict_to_camel_dict(scrub_none_parameters(preferences), capitalize_first=True)
     cmd_invocations = {
-        "cancelled": conn.cancel_instance_refresh,
-        "started": conn.start_instance_refresh,
+        "cancelled": cancel_instance_refresh,
+        "started": start_instance_refresh,
     }
     try:
         if module.check_mode:
+            ongoing_refresh = describe_instance_refreshes(conn, auto_scaling_group_name=asg_name).get(
+                "InstanceRefreshes", []
+            )
             if asg_state == "started":
-                ongoing_refresh = conn.describe_instance_refreshes(AutoScalingGroupName=asg_name).get(
-                    "InstanceRefreshes", "[]"
-                )
                 if ongoing_refresh:
                     module.exit_json(
                         changed=False,
@@ -209,26 +245,23 @@ def start_or_cancel_instance_refresh(conn, module):
                 else:
                     module.exit_json(changed=True, msg="Would have started instance refresh if not in check mode.")
             elif asg_state == "cancelled":
-                ongoing_refresh = conn.describe_instance_refreshes(AutoScalingGroupName=asg_name).get(
-                    "InstanceRefreshes", "[]"
-                )[0]
-                if ongoing_refresh.get("Status", "") in ["Cancelling", "Cancelled"]:
+                if ongoing_refresh and ongoing_refresh[0].get("Status", "") in ["Cancelling", "Cancelled"]:
                     module.exit_json(
                         changed=False,
                         msg="In check_mode - Instance Refresh already cancelled or is pending cancellation.",
                     )
                 elif not ongoing_refresh:
-                    module.exit_json(chaned=False, msg="In check_mode - No active referesh found, nothing to cancel.")
+                    module.exit_json(changed=False, msg="In check_mode - No active referesh found, nothing to cancel.")
                 else:
                     module.exit_json(changed=True, msg="Would have cancelled instance refresh if not in check mode.")
-        result = cmd_invocations[asg_state](aws_retry=True, **args)
-        instance_refreshes = conn.describe_instance_refreshes(
-            AutoScalingGroupName=asg_name, InstanceRefreshIds=[result["InstanceRefreshId"]]
+        instance_refresh_id = cmd_invocations[asg_state](conn, auto_scaling_group_name=asg_name, **args)
+        response = describe_instance_refreshes(
+            conn, auto_scaling_group_name=asg_name, instance_refresh_ids=[instance_refresh_id]
         )
-        result = dict(instance_refreshes=camel_dict_to_snake_dict(instance_refreshes["InstanceRefreshes"][0]))
-        return module.exit_json(**result)
-    except (BotoCoreError, ClientError) as e:
-        module.fail_json_aws(e, msg=f"Failed to {asg_state.replace('ed', '')} InstanceRefresh")
+        result = dict(instance_refreshes=camel_dict_to_snake_dict(response["InstanceRefreshes"][0]))
+        module.exit_json(**result)
+    except AnsibleAutoScalingError as e:
+        module.fail_json_aws(e, msg=f"Failed to {asg_state.replace('ed', '')} InstanceRefresh: {e}")
 
 
 def main():
@@ -246,6 +279,8 @@ def main():
             options=dict(
                 min_healthy_percentage=dict(type="int", default=90),
                 instance_warmup=dict(type="int"),
+                skip_matching=dict(type="bool"),
+                max_healthy_percentage=dict(type="int"),
             ),
         ),
     )
@@ -254,10 +289,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-    autoscaling = module.client(
-        "autoscaling",
-        retry_decorator=AWSRetry.jittered_backoff(retries=10, catch_extra_error_codes=["InstanceRefreshInProgress"]),
-    )
+    autoscaling = module.client("autoscaling")
 
     start_or_cancel_instance_refresh(autoscaling, module)
 

--- a/plugins/modules/ec2_vpc_egress_igw.py
+++ b/plugins/modules/ec2_vpc_egress_igw.py
@@ -25,10 +25,13 @@ options:
     default: present
     choices: [ 'present', 'absent' ]
     type: str
+notes:
+  - Support for O(tags) and O(purge_tags) was added in release 9.0.0.
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
   - amazon.aws.boto3
+  - amazon.aws.tags.modules
 """
 
 EXAMPLES = r"""
@@ -36,10 +39,15 @@ EXAMPLES = r"""
 
 # Ensure that the VPC has an Internet Gateway.
 # The Internet Gateway ID is can be accessed via {{eigw.gateway_id}} for use in setting up NATs etc.
-- community.aws.ec2_vpc_egress_igw:
+- name: Create Egress internet only gateway
+  community.aws.ec2_vpc_egress_igw:
     vpc_id: vpc-abcdefgh
     state: present
-  register: eigw
+
+- name: Delete Egress internet only gateway
+  community.aws.ec2_vpc_egress_igw:
+    vpc_id: vpc-abcdefgh
+    state: absent
 """
 
 RETURN = r"""
@@ -53,22 +61,30 @@ vpc_id:
     returned: always
     type: str
     sample: vpc-012345678
+tags:
+    description: Any tags assigned to the internet gateway.
+    returned: always
+    type: dict
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Union
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import create_egress_only_internet_gateway
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import delete_egress_only_internet_gateway
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import describe_egress_only_internet_gateways
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ensure_ec2_tags
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 
 
-def delete_eigw(module, connection, eigw_id):
+def delete_eigw(module: AnsibleAWSModule, connection, eigw_id: str) -> Dict[str, Union[str, bool]]:
     """
     Delete EIGW.
 
@@ -76,27 +92,23 @@ def delete_eigw(module, connection, eigw_id):
     connection : boto3 client connection object
     eigw_id    : ID of the EIGW to delete
     """
-    changed = False
+
+    vpc_id = module.params.get("vpc_id")
+
+    if module.check_mode:
+        return dict(
+            changed=True, msg=f"Would have deleted Egress internet only Gateway id '{eigw_id}' if not in check mode."
+        )
 
     try:
-        response = connection.delete_egress_only_internet_gateway(
-            aws_retry=True, DryRun=module.check_mode, EgressOnlyInternetGatewayId=eigw_id
-        )
-    except is_boto3_error_code("DryRunOperation"):
-        changed = True
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg=f"Could not delete Egress-Only Internet Gateway {eigw_id} from VPC {module.vpc_id}")
+        changed = delete_egress_only_internet_gateway(connection, egress_only_internet_gateway_id=eigw_id)
+    except AnsibleEC2Error as e:
+        module.fail_json_aws(e)
 
-    if not module.check_mode:
-        changed = response.get("ReturnCode", False)
-
-    return changed
+    return dict(changed=changed)
 
 
-def create_eigw(module, connection, vpc_id):
+def create_eigw(module: AnsibleAWSModule, connection, vpc_id: str) -> Dict[str, Union[str, bool]]:
     """
     Create EIGW.
 
@@ -104,43 +116,35 @@ def create_eigw(module, connection, vpc_id):
     connection   : boto3 client connection object
     vpc_id       : ID of the VPC we are operating on
     """
+
+    if module.check_mode:
+        return dict(changed=True, msg="Would have created Egress internet only Gateway if not in check mode.")
+
     gateway_id = None
     changed = False
 
     try:
-        response = connection.create_egress_only_internet_gateway(
-            aws_retry=True, DryRun=module.check_mode, VpcId=vpc_id
-        )
-    except is_boto3_error_code("DryRunOperation"):
-        # When boto3 method is run with DryRun=True it returns an error on success
-        # We need to catch the error and return something valid
+        response = create_egress_only_internet_gateway(connection, vpc_id=vpc_id, tags=module.params.get("tags"))
         changed = True
-    except is_boto3_error_code("InvalidVpcID.NotFound") as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg=f"invalid vpc ID '{vpc_id}' provided")
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg=f"Could not create Egress-Only Internet Gateway for vpc ID {vpc_id}")
+    except AnsibleEC2Error as e:
+        module.fail_json_aws(e)
 
-    if not module.check_mode:
-        gateway = response.get("EgressOnlyInternetGateway", {})
-        state = gateway.get("Attachments", [{}])[0].get("State")
-        gateway_id = gateway.get("EgressOnlyInternetGatewayId")
+    gateway = response.get("EgressOnlyInternetGateway", {})
+    state = gateway.get("Attachments", [{}])[0].get("State")
+    gateway_id = gateway.get("EgressOnlyInternetGatewayId")
+    tags = boto3_tag_list_to_ansible_dict(gateway.get("Tags", []))
 
-        if gateway_id and state in ("attached", "attaching"):
-            changed = True
-        else:
-            # EIGW gave back a bad attachment state or an invalid response so we error out
-            module.fail_json(
-                msg=f"Unable to create and attach Egress Only Internet Gateway to VPCId: {vpc_id}. Bad or no state in response",
-                **camel_dict_to_snake_dict(response),
-            )
+    if not gateway_id or state not in ("attached", "attaching"):
+        # EIGW gave back a bad attachment state or an invalid response so we error out
+        module.fail_json(
+            msg=f"Unable to create and attach Egress Only Internet Gateway to VPCId: {vpc_id}. Bad or no state in response",
+            **camel_dict_to_snake_dict(response),
+        )
 
-    return changed, gateway_id
+    return dict(changed=changed, gateway_id=gateway_id, tags=tags)
 
 
-def describe_eigws(module, connection, vpc_id):
+def find_egress_only_igw(module: AnsibleAWSModule, connection, vpc_id: str) -> Optional[Dict[str, Any]]:
     """
     Describe EIGWs.
 
@@ -148,43 +152,80 @@ def describe_eigws(module, connection, vpc_id):
     connection : boto3 client connection object
     vpc_id     : ID of the VPC we are operating on
     """
-    gateway_id = None
+    result = None
 
     try:
-        response = connection.describe_egress_only_internet_gateways(aws_retry=True)
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        module.fail_json_aws(e, msg="Could not get list of existing Egress-Only Internet Gateways")
+        for eigw in describe_egress_only_internet_gateways(connection):
+            for attachment in eigw.get("Attachments", []):
+                if attachment.get("VpcId") == vpc_id and attachment.get("State") in ("attached", "attaching"):
+                    return {
+                        "gateway_id": eigw.get("EgressOnlyInternetGatewayId"),
+                        "tags": boto3_tag_list_to_ansible_dict(eigw.get("Tags", [])),
+                    }
+    except AnsibleEC2Error as e:
+        module.fail_json_aws(e)
 
-    for eigw in response.get("EgressOnlyInternetGateways", []):
-        for attachment in eigw.get("Attachments", []):
-            if attachment.get("VpcId") == vpc_id and attachment.get("State") in ("attached", "attaching"):
-                gateway_id = eigw.get("EgressOnlyInternetGatewayId")
+    return result
 
-    return gateway_id
+
+def ensure_present(connection, module: AnsibleAWSModule, existing: Optional[Dict[str, Any]]) -> None:
+    vpc_id = module.params.get("vpc_id")
+    result = dict(vpc_id=vpc_id, changed=False)
+
+    if not existing:
+        result.update(create_eigw(module, connection, vpc_id))
+    else:
+        egress_only_igw_id = existing.get("gateway_id")
+        changed = False
+        result = existing
+        tags = module.params.get("tags")
+        purge_tags = module.params.get("purge_tags")
+        if tags is not None:
+            changed = ensure_ec2_tags(
+                connection,
+                module,
+                egress_only_igw_id,
+                resource_type="egress-only-internet-gateway",
+                tags=tags,
+                purge_tags=purge_tags,
+            )
+        result.update(dict(changed=changed, vpc_id=vpc_id))
+
+    module.exit_json(**result)
+
+
+def ensure_absent(connection, module: AnsibleAWSModule, existing: Optional[Dict[str, Any]]) -> None:
+    vpc_id = module.params.get("vpc_id")
+    if not existing:
+        module.exit_json(changed=False, msg=f"No Egress only internet gateway attached to the VPC id '{vpc_id}'")
+
+    egress_only_igw_id = existing.get("gateway_id")
+    result = dict(gateway_id=egress_only_igw_id, vpc_id=vpc_id, changed=False)
+    result.update(delete_eigw(module, connection, egress_only_igw_id))
+    module.exit_json(**result)
 
 
 def main():
-    argument_spec = dict(vpc_id=dict(required=True), state=dict(default="present", choices=["present", "absent"]))
+    argument_spec = dict(
+        vpc_id=dict(required=True),
+        state=dict(default="present", choices=["present", "absent"]),
+        tags=dict(type="dict", aliases=["resource_tags"]),
+        purge_tags=dict(type="bool", default=True),
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
-    retry_decorator = AWSRetry.jittered_backoff(retries=10)
-    connection = module.client("ec2", retry_decorator=retry_decorator)
+    connection = module.client("ec2")
 
     vpc_id = module.params.get("vpc_id")
     state = module.params.get("state")
 
-    eigw_id = describe_eigws(module, connection, vpc_id)
+    existing_egress_only_igw = find_egress_only_igw(module, connection, vpc_id)
 
-    result = dict(gateway_id=eigw_id, vpc_id=vpc_id)
-    changed = False
-
-    if state == "present" and not eigw_id:
-        changed, result["gateway_id"] = create_eigw(module, connection, vpc_id)
-    elif state == "absent" and eigw_id:
-        changed = delete_eigw(module, connection, eigw_id)
-
-    module.exit_json(changed=changed, **result)
+    if state == "present":
+        ensure_present(connection, module, existing_egress_only_igw)
+    else:
+        ensure_absent(connection, module, existing_egress_only_igw)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ec2_vpc_vgw.py
+++ b/plugins/modules/ec2_vpc_vgw.py
@@ -420,6 +420,7 @@ def ensure_vgw_absent(client, module):
     changed = False
     params = dict()
     result = dict()
+    deleted_vgw = None
     params["Name"] = module.params.get("name")
     params["VpcId"] = module.params.get("vpc_id")
     params["Type"] = module.params.get("type")

--- a/plugins/modules/ecs_cluster.py
+++ b/plugins/modules/ecs_cluster.py
@@ -339,7 +339,7 @@ def main():
     elif module.params["state"] == "has_instances":
         if not existing:
             module.fail_json(msg="Cluster '" + module.params["name"] + " not found.")
-            return
+
         # it exists, so we should delete it and mark changed.
         # return info about the cluster deleted
         delay = module.params["delay"]
@@ -361,7 +361,6 @@ def main():
                 + str(delay)
                 + " seconds each."
             )
-            return
 
     module.exit_json(**results)
 

--- a/plugins/modules/ecs_service.py
+++ b/plugins/modules/ecs_service.py
@@ -1248,7 +1248,7 @@ def main():
     elif module.params["state"] == "deleting":
         if not existing:
             module.fail_json(msg="Service '" + module.params["name"] + " not found.")
-            return
+
         # it exists, so we should delete it and mark changed.
         # return info about the cluster deleted
         delay = module.params["delay"]
@@ -1263,7 +1263,6 @@ def main():
             time.sleep(delay)
         if i is repeat - 1:
             module.fail_json(msg=f"Service still not deleted after {repeat} tries of {delay} seconds each.")
-            return
 
     module.exit_json(**results)
 

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -8,9 +8,9 @@ DOCUMENTATION = r"""
 ---
 module: elb_classic_lb_info
 version_added: 1.0.0
-short_description: Gather information about EC2 Elastic Load Balancers in AWS
+short_description: Gather information about EC2 Classic Elastic Load Balancers in AWS
 description:
-  - Gather information about EC2 Elastic Load Balancers in AWS
+  - Gather information about EC2 Classic Elastic Load Balancers in AWS.
 author:
   - "Michael Schultz (@mjschultz)"
   - "Fernando Jose Pando (@nand0p)"
@@ -29,26 +29,26 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 # Note: These examples do not set authentication details, see the AWS Guide for details.
-# Output format tries to match amazon.aws.ec2_elb_lb module input parameters
+# Output format tries to match amazon.aws.elb_classic_lb module input parameters
 
-# Gather information about all ELBs
-- community.aws.elb_classic_lb_info:
+- name: Gather information about all ELBs
+  community.aws.elb_classic_lb_info:
   register: elb_info
 
 - ansible.builtin.debug:
     msg: "{{ item.dns_name }}"
   loop: "{{ elb_info.elbs }}"
 
-# Gather information about a particular ELB
-- community.aws.elb_classic_lb_info:
+- name: Gather information about a particular ELB
+  community.aws.elb_classic_lb_info:
     names: frontend-prod-elb
   register: elb_info
 
 - ansible.builtin.debug:
     msg: "{{ elb_info.elbs.0.dns_name }}"
 
-# Gather information about a set of ELBs
-- community.aws.elb_classic_lb_info:
+- name: Gather information about a set of ELBs
+  community.aws.elb_classic_lb_info:
     names:
       - frontend-prod-elb
       - backend-prod-elb
@@ -61,69 +61,281 @@ EXAMPLES = r"""
 
 RETURN = r"""
 elbs:
-  description: a list of load balancers
+  description: A list of load balancers.
   returned: always
   type: list
-  sample:
-    elbs:
-      - attributes:
-          access_log:
-            enabled: false
-          connection_draining:
-            enabled: true
-            timeout: 300
-          connection_settings:
-            idle_timeout: 60
-          cross_zone_load_balancing:
-            enabled: true
-        availability_zones:
-          - "us-east-1a"
-          - "us-east-1b"
-          - "us-east-1c"
-          - "us-east-1d"
-          - "us-east-1e"
-        backend_server_description: []
-        canonical_hosted_zone_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
-        canonical_hosted_zone_name_id: XXXXXXXXXXXXXX
-        created_time: '2017-08-23T18:25:03.280000+00:00'
-        dns_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
-        health_check:
-          healthy_threshold: 10
-          interval: 30
-          target: HTTP:80/index.html
-          timeout: 5
-          unhealthy_threshold: 2
-        instances: []
-        instances_inservice: []
-        instances_inservice_count: 0
-        instances_outofservice: []
-        instances_outofservice_count: 0
-        instances_unknownservice: []
-        instances_unknownservice_count: 0
-        listener_descriptions:
-          - listener:
-              instance_port: 80
-              instance_protocol: HTTP
-              load_balancer_port: 80
-              protocol: HTTP
-            policy_names: []
-        load_balancer_name: test-lb
-        policies:
-          app_cookie_stickiness_policies: []
-          lb_cookie_stickiness_policies: []
-          other_policies: []
-        scheme: internet-facing
-        security_groups:
-          - sg-29d13055
-        source_security_group:
-          group_name: default
-          owner_alias: XXXXXXXXXXXX
-        subnets:
-          - subnet-XXXXXXXX
-          - subnet-XXXXXXXX
-        tags: {}
-        vpc_id: vpc-c248fda4
+  elements: dict
+  contains:
+    attributes:
+      description: Information about the load balancer attributes.
+      returned: always
+      type: dict
+      contains:
+        access_log:
+          description: Information on whether access logs are enabled or not.
+          type: dict
+          sample: {
+                    "enabled": false
+                  }
+        additional_attributes:
+          description: Information about additional load balancer attributes.
+          type: list
+          elements: dict
+          sample: [
+                    {
+                        "key": "elb.http.desyncmitigationmode",
+                        "value": "defensive"
+                    }
+                  ]
+        connection_draining:
+          description:
+            - Information on connection draining configuration of elastic load balancer.
+          type: dict
+          sample: {
+                    "enabled": true,
+                    "timeout": 300
+                  }
+          contains:
+            enabled:
+              description: Whether connection draining is enabled.
+              type: bool
+              returned: always
+            timeout:
+              description: The maximum time, in seconds, to keep the existing connections open before deregistering the instances.
+              type: int
+              returned: always
+        connection_settings:
+          description: Information on connection settings.
+          type: dict
+          sample: {
+                    "idle_timeout": 60
+                  }
+        cross_zone_load_balancing:
+          description: Information on whether cross zone load balancing is enabled or not.
+          type: dict
+          sample: {
+                    "enabled": true
+                  }
+    availability_zones:
+      description: The Availability Zones for the load balancer.
+      type: list
+      elements: str
+      returned: always
+      sample: [
+                "us-west-2a"
+              ]
+    backend_server_descriptions:
+      description: Information about your EC2 instances.
+      type: list
+      elements: dict
+      returned: always
+      sample: [
+                {
+                    instance_port: 8085,
+                    policy_names: [
+                        'MyPolicy1',
+                    ]
+                },
+              ]
+    canonical_hosted_zone_name:
+      description: The DNS name of the load balancer.
+      type: str
+      returned: always
+      sample: "test-123456789.us-west-2.elb.amazonaws.com"
+    canonical_hosted_zone_name_id:
+      description: The ID of the Amazon Route 53 hosted zone for the load balancer.
+      type: str
+      returned: always
+      sample: "Z1Z1ZZ5HABSF5"
+    created_time:
+      description: The date and time the load balancer was created.
+      type: str
+      returned: always
+      sample: "2024-09-04T17:52:22.270000+00:00"
+    dns_name:
+      description: The DNS name of the load balancer.
+      type: str
+      returned: "always"
+      sample: "test-123456789.us-west-2.elb.amazonaws.com"
+    health_check:
+      description: Information about the health checks conducted on the load balancer.
+      type: dict
+      returned: always
+      sample: {
+                "healthy_threshold": 10,
+                "interval": 5,
+                "target": "HTTP:80/index.html",
+                "timeout": 2,
+                "unhealthy_threshold": 2
+              }
+      contains:
+        healthy_threshold:
+          description: The number of consecutive health checks successes required before moving the instance to the Healthy state.
+          type: int
+          returned: always
+        interval:
+          description: The approximate interval, in seconds, between health checks of an individual instance.
+          type: int
+          returned: always
+        target:
+          description: The instance being checked. The protocol is either TCP, HTTP, HTTPS, or SSL. The range of valid ports is one (1) through 65535.
+          type: str
+          returned: always
+        timeout:
+          description: The amount of time, in seconds, during which no response means a failed health check.
+          type: int
+          returned: always
+        unhealthy_threshold:
+          description: The number of consecutive health checks successes required before moving the instance to the Unhealthy state.
+          type: int
+          returned: always
+    instances:
+      description: The IDs of the instances for the load balancer.
+      type: list
+      elements: dict
+      returned: always
+      sample: [
+                {
+                    "instance_id": "i-11d1f111ea111111b"
+                }
+              ]
+    instances_inservice:
+      description: Information about instances for load balancer in state "InService".
+      type: list
+      returned: always
+      sample: [
+                "i-11d1f111ea111111b"
+              ]
+    instances_inservice_count:
+      description: Total number of instances for load balancer with state "InService".
+      type: int
+      returned: always
+      sample: 1
+    instances_outofservice:
+      description: Information about instances for load balancer in state "OutOfService".
+      type: list
+      returned: always
+      sample: [
+                "i-11d1f111ea111111b"
+              ]
+    instances_outofservice_count:
+      description: Total number of instances for load balancer with state "OutOfService".
+      type: int
+      returned: always
+      sample: 0
+    instances_unknownservice:
+      description: Information about instances for load balancer in state "Unknown".
+      type: list
+      returned: always
+      sample: [
+                "i-11d1f111ea111111b"
+              ]
+    instances_unknownservice_count:
+      description: Total number of instances for load balancer with state "Unknown".
+      type: int
+      returned: always
+      sample: 1
+    listener_descriptions:
+      description: Information about the listeners for the load balancer.
+      type: list
+      elements: dict
+      returned: always
+      sample: [
+                {
+                  "listener": {
+                      "instance_port": 80,
+                      "instance_protocol": "HTTP",
+                      "load_balancer_port": 80,
+                      "protocol": "HTTP"
+                  },
+                  "policy_names": []
+                }
+              ]
+    load_balancer_name:
+      description: The name of the elastic load balancer.
+      type: str
+      returned: always
+      sample: "MyLoadBalancer"
+    policies:
+      description: Information about the policies defined for the load balancer.
+      type: dict
+      returned: always
+      sample: {
+                "app_cookie_stickiness_policies": [],
+                "lb_cookie_stickiness_policies": [],
+                "other_policies": []
+              }
+      contains:
+        app_cookie_stickiness_policies:
+          description: The stickiness policies created using CreateAppCookieStickinessPolicy.
+          type: list
+          returned: always
+        lb_cookie_stickiness_policies:
+          description: The stickiness policies created using CreateLBCookieStickinessPolicy.
+          type: list
+          returned: always
+        other_policies:
+          description: The policies other than the stickiness policies.
+          type: list
+          returned: always
+    scheme:
+      description: The type of load balancer.
+      type: str
+      returned: always
+      sample: "internet-facing"
+    security_groups:
+      description: The security groups for the load balancer.
+      type: list
+      returned: always
+      sample: [
+                "sg-111111af1111cb111"
+              ]
+    source_security_group:
+      description:
+        - The security group for the load balancer,
+          which are used as part of inbound rules for registered instances.
+      type: dict
+      returned: always
+      sample: {
+                  "group_name": "default",
+                  "owner_alias": "721111111111"
+              }
+      contains:
+        group_name:
+          description: The name of the security group.
+          type: str
+          returned: always
+        owner_alias:
+          description: The owner of the security group.
+          type: str
+          returned: always
+    subnets:
+      description: The IDs of the subnets for the load balancer.
+      type: list
+      returned: always
+      sample: [
+                "subnet-111111af1111cb111"
+              ]
+    tags:
+      description: The tags associated with a load balancer.
+      type: dict
+      returned: always
+      sample: {
+                "Env": "Dev",
+                "Owner": "Dev001"
+              }
+    vpc_id:
+      description: The ID of the VPC for the load balancer.
+      type: str
+      returned: always
+      sample: "vpc-0cc28c9e20d111111"
 """
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
 try:
     import botocore
@@ -133,16 +345,22 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
-from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 
-MAX_AWS_RETRIES = 5
-MAX_AWS_DELAY = 5
+def list_elbs(connection: Any, load_balancer_names: List[str]) -> List[Dict]:
+    """
+    List Elastic Load Balancers (ELBs) and their detailed information.
 
+    Parameters:
+      connection (boto3.client): The Boto3 ELB client object.
+      load_balancer_names (List[str]): List of ELB names to gather information about.
 
-def list_elbs(connection, load_balancer_names):
+    Returns:
+      A list of dictionaries where each dictionary contains informtion about one ELB.
+    """
     results = []
 
     if not load_balancer_names:
@@ -157,7 +375,17 @@ def list_elbs(connection, load_balancer_names):
     return results
 
 
-def describe_elb(connection, lb):
+def describe_elb(connection: Any, lb: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Describes an Elastic Load Balancer (ELB).
+
+    Parameters:
+      connection (boto3.client): The Boto3 ELB client object.
+      lb (Dict): Dictionary containing ELB .
+
+    Returns:
+      A dictionary with detailed information of the ELB.
+    """
     description = camel_dict_to_snake_dict(lb)
     name = lb["LoadBalancerName"]
     instances = lb.get("Instances", [])
@@ -176,12 +404,31 @@ def describe_elb(connection, lb):
 
 
 @AWSRetry.jittered_backoff()
-def get_all_lb(connection):
+def get_all_lb(connection: Any) -> List:
+    """
+    Get paginated result for information of all Elastic Load Balancers.
+
+    Parameters:
+        connection (boto3.client): The Boto3 ELB client object.
+
+    Returns:
+        A list of dictionaries containing descriptions of all ELBs.
+    """
     paginator = connection.get_paginator("describe_load_balancers")
     return paginator.paginate().build_full_result()["LoadBalancerDescriptions"]
 
 
-def get_lb(connection, load_balancer_name):
+def get_lb(connection: Any, load_balancer_name: str) -> Union[Dict[str, Any], List]:
+    """
+    Describes a specific Elastic Load Balancer (ELB) by name.
+
+    Parameters:
+      connection (boto3.client): The Boto3 ELB client object.
+      load_balancer_name (str): Name of the ELB to gather information about.
+
+    Returns:
+      A dictionary with detailed information of the specified ELB.
+    """
     try:
         return connection.describe_load_balancers(aws_retry=True, LoadBalancerNames=[load_balancer_name])[
             "LoadBalancerDescriptions"
@@ -190,21 +437,55 @@ def get_lb(connection, load_balancer_name):
         return []
 
 
-def get_lb_attributes(connection, load_balancer_name):
+def get_lb_attributes(connection: Any, load_balancer_name: str) -> Dict[str, Any]:
+    """
+    Retrieves attributes of specific Elastic Load Balancer (ELB) by name.
+
+    Parameters:
+      connection (boto3.client): The Boto3 ELB client object.
+      load_balancer_name (str): Name of the ELB to gather information about.
+
+    Returns:
+      A dictionary with detailed information of the attributes of specified ELB.
+    """
     attributes = connection.describe_load_balancer_attributes(aws_retry=True, LoadBalancerName=load_balancer_name).get(
         "LoadBalancerAttributes", {}
     )
     return camel_dict_to_snake_dict(attributes)
 
 
-def get_tags(connection, load_balancer_name):
+def get_tags(connection: Any, load_balancer_name: str) -> Dict[str, Any]:
+    """
+    Retrieves tags of specific Elastic Load Balancer (ELB) by name.
+
+    Parameters:
+      connection (boto3.client): The Boto3 ELB client object.
+      load_balancer_name (str): Name of the ELB to gather information about.
+
+    Returns:
+      A dictionary of tags associated with the specified ELB.
+    """
     tags = connection.describe_tags(aws_retry=True, LoadBalancerNames=[load_balancer_name])["TagDescriptions"]
     if not tags:
         return {}
     return boto3_tag_list_to_ansible_dict(tags[0]["Tags"])
 
 
-def lb_instance_health(connection, load_balancer_name, instances, state):
+def lb_instance_health(
+    connection: Any, load_balancer_name: str, instances: List[Dict[str, Any]], state: str
+) -> Tuple[List[str], int]:
+    """
+    Describes the health status of instances associated with a specific Elastic Load Balancer (ELB).
+
+    Parameters:
+        connection (Any): The Boto3 client object for ELB.
+        load_balancer_name (str): The name of the ELB.
+        instances (List[Dict]): List of dictionaries containing instances associated with the ELB.
+        state (str): The health state to filter by (e.g., "InService", "OutOfService", "Unknown").
+
+    Returns:
+        Tuple[List, int]: A tuple containing a list of instance IDs matching state and the count of matching instances.
+    """
     instance_states = connection.describe_instance_health(LoadBalancerName=load_balancer_name, Instances=instances).get(
         "InstanceStates", []
     )
@@ -221,9 +502,7 @@ def main():
         supports_check_mode=True,
     )
 
-    connection = module.client(
-        "elb", retry_decorator=AWSRetry.jittered_backoff(retries=MAX_AWS_RETRIES, delay=MAX_AWS_DELAY)
-    )
+    connection = module.client("elb", retry_decorator=AWSRetry.jittered_backoff(retries=5, delay=5))
 
     try:
         elbs = list_elbs(connection, module.params.get("names"))

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/instance_refresh_info.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/instance_refresh_info.yml
@@ -1,0 +1,99 @@
+---
+- name: Test getting info for an ASG name
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+  register: output
+
+- name: Assert that the correct number of records are returned
+  assert:
+    that:
+      - output.instance_refreshes | map(attribute='instance_refresh_id') | unique | length == 7
+
+- name: Test using fake refresh ID
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+    ids: ['0e367f58-blabla-bla-bla-ca870dc5dbfe']
+  register: output
+
+- name: Assert that no record is returned
+  assert:
+    that:
+      - output.instance_refreshes | length == 0
+
+- name: Test using a real refresh ID
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+    ids: [ '{{ refreshout.instance_refreshes.instance_refresh_id }}' ]
+  register: output
+
+- name: Assert that the correct record is returned
+  assert:
+    that:
+      - output.instance_refreshes | length == 1
+
+- name: Test getting info for an ASG name which doesn't exist
+  autoscaling_instance_refresh_info:
+    name: n0n3x1stentname27b
+  ignore_errors: true
+  register: output
+
+- name: Assert that module failed to return record
+  assert:
+    that:
+      - "'Failed to describe InstanceRefreshes: An error occurred (ValidationError) when calling the DescribeInstanceRefreshes operation: AutoScalingGroup name not found - AutoScalingGroup n0n3x1stentname27b not found' in output.msg"
+
+- name: Retrieve instance refresh info
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+  register: output
+
+- name: Assert that the correct number of records are returned
+  assert:
+    that:
+      - output.instance_refreshes | length == 7
+
+- name: Retrieve instance refresh info using next_token
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+    next_token: "fake-token-123"
+  ignore_errors: true
+  register: output
+
+- name: Assert that valid message with fake-token is returned
+  assert:
+    that:
+      - '"Failed to describe InstanceRefreshes: An error occurred (InvalidNextToken) when calling the DescribeInstanceRefreshes operation: The token ''********'' is invalid." in output.msg'
+
+- name: Retrieve instance refresh info using max_records
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+    max_records: 1
+  register: output_with_token
+
+- name: Assert that max records=1 returns no more than one record
+  assert:
+    that:
+      - output_with_token.instance_refreshes | length == 1
+
+- name: Retrieve instance refresh using valid token
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+    next_token: "{{ output_with_token.next_token }}"
+  register: output
+
+- name: Assert that valid message with real-token is returned
+  assert:
+    that:
+      - output.instance_refreshes | length == 6
+
+- name: Test using both real nextToken and max_records=1
+  autoscaling_instance_refresh_info:
+    name: "{{ asg_name }}"
+    max_records: 1
+    next_token: "{{ output_with_token.next_token }}"
+  register: output
+
+- name: Assert that only one instance refresh is returned
+  assert:
+    that:
+      - output.instance_refreshes | length == 1

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/main.yml
@@ -35,7 +35,7 @@
           Name: "{{ subnet_name }}"
       register: testing_subnet
 
-    - name: create routing rules
+    - name: Create routing rules
       ec2_vpc_route_table:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         tags:
@@ -46,7 +46,7 @@
         subnets:
           - "{{ testing_subnet.subnet.id }}"
 
-    - name: create a security group with the vpc created in the ec2_setup
+    - name: Create a security group with the vpc created in the ec2_setup
       ec2_security_group:
         name: "{{ sg_name }}"
         description: a security group for ansible tests
@@ -62,7 +62,7 @@
             cidr_ip: 0.0.0.0/0
       register: sg
 
-    - name: ensure launch configs exist
+    - name: Ensure launch configs exist
       autoscaling_launch_config:
         name: "{{ item }}"
         assign_public_ip: true
@@ -80,7 +80,7 @@
         - "{{ lc_name_1 }}"
         - "{{ lc_name_2 }}"
 
-    - name: launch asg and do not wait for instances to be deemed healthy (no ELB)
+    - name: Launch asg and do not wait for instances to be deemed healthy (no ELB)
       autoscaling_group:
         name: "{{ asg_name }}"
         launch_config_name: "{{ lc_name_1 }}"
@@ -92,335 +92,44 @@
         state: present
       register: output
 
-    - assert:
+    - name: Assert that there is no viable instance
+      assert:
         that:
         - "output.viable_instances == 0"
 
   # ============================================================
-
-    - name: test invalid cancelation - V1 - (pre-refresh)
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      ignore_errors: yes
-      register: result
-
-    - assert:
-        that:
-        - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress or pending Instance Refresh found for Auto Scaling group ' ~ resource_prefix ~ '-asg' in result.msg"
-
-    - name: test starting a refresh with a valid ASG name - check_mode
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-      check_mode: true
-      register: output
-
-    - assert:
-        that:
-        - output is not failed
-        - output is changed
-        - '"autoscaling:StartInstanceRefresh" not in output.resource_actions'
-
-    - name: test starting a refresh with a valid ASG name
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-      register: output
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: test starting a refresh with a valid ASG name - Idempotent
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-      ignore_errors: true
-      register: output
-
-    - assert:
-        that:
-          - output is not changed
-          - '"Failed to start InstanceRefresh: An error occurred (InstanceRefreshInProgress) when calling the StartInstanceRefresh operation: An Instance Refresh is already in progress and blocks the execution of this Instance Refresh." in output.msg'
-
-    - name: test starting a refresh with a valid ASG name - Idempotent (check_mode)
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-      ignore_errors: true
-      check_mode: true
-      register: output
-
-    - assert:
-        that:
-          - output is not changed
-          - output is not failed
-          - '"In check_mode - Instance Refresh is already in progress, can not start new instance refresh." in output.msg'
-
-    - name: test starting a refresh with a nonexistent ASG name
-      autoscaling_instance_refresh:
-        name: "nonexistentname-asg"
-        state: "started"
-      ignore_errors: yes
-      register: result
-
-    - assert:
-        that:
-        - "'Failed to start InstanceRefresh: An error occurred (ValidationError) when calling the StartInstanceRefresh operation: AutoScalingGroup name not found' in result.msg"
-
-    - name: test canceling a refresh with an ASG name - check_mode
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      check_mode: true
-      register: output
-
-    - assert:
-        that:
-        - output is not failed
-        - output is changed
-        - '"autoscaling:CancelInstanceRefresh" not in output.resource_actions'
-
-    - name: test canceling a refresh with an ASG name
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      register: output
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: test canceling a refresh with a ASG name - Idempotent
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-        - output is not changed
-
-    - name: test cancelling a refresh with a valid ASG name - Idempotent (check_mode)
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      ignore_errors: true
-      check_mode: true
-      register: output
-
-    - assert:
-        that:
-          - output is not changed
-          - output is not failed
-
-    - name: test starting a refresh with an ASG name and preferences dict
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-        preferences:
-          min_healthy_percentage: 10
-          instance_warmup: 10
-      retries: 5
-      register: output
-      until: output is not failed
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: re-test canceling a refresh with an ASG name
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      register: output
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: test valid start - V1 - (with preferences missing instance_warmup)
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-        preferences:
-          min_healthy_percentage: 10
-      ignore_errors: yes
-      retries: 5
-      register: output
-      until: output is not failed
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: re-test canceling a refresh with an ASG name
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-      register: output
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: test valid start - V2 - (with preferences missing min_healthy_percentage)
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "started"
-        preferences:
-          instance_warmup: 10
-      retries: 5
-      register: output
-      until: output is not failed
-      ignore_errors: yes
-
-    - assert:
-        that:
-        - "'instance_refresh_id' in output.instance_refreshes"
-
-    - name: test invalid cancelation - V2 - (with preferences)
-      autoscaling_instance_refresh:
-        name: "{{ asg_name }}"
-        state: "cancelled"
-        preferences:
-          min_healthy_percentage: 10
-          instance_warmup: 10
-      ignore_errors: yes
-      register: result
-
-    - assert:
-        that:
-        - "'can not pass preferences dict when canceling a refresh' in result.msg"
-
+    - name: Run test with start_cancel_instance_refresh.yml
+      include_tasks: start_cancel_instance_refresh.yml
+    
   # ============================================================
 
-    - name: run setup with refresh_and_cancel_three_times.yml
+    - name: Run test with refresh_and_cancel_three_times.yml
       include_tasks: refresh_and_cancel_three_times.yml
       loop: "{{ query('sequence', 'start=1 end=3') }}"
 
-    - name: test getting info for an ASG name
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        region: "{{ aws_region }}"
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output | community.general.json_query(inst_refresh_id_json_query) | unique | length == 7
-      vars:
-        inst_refresh_id_json_query: instance_refreshes[].instance_refresh_id
-
-    - name: test using fake refresh ID
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        ids: ['0e367f58-blabla-bla-bla-ca870dc5dbfe']
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output.instance_refreshes | length == 0
-
-    - name: test using a real refresh ID
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        ids: [ '{{ refreshout.instance_refreshes.instance_refresh_id }}' ]
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output.instance_refreshes | length == 1
-
-    - name: test getting info for an ASG name which doesn't exist
-      autoscaling_instance_refresh_info:
-        name: n0n3x1stentname27b
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - "'Failed to describe InstanceRefreshes: An error occurred (ValidationError) when calling the DescribeInstanceRefreshes operation: AutoScalingGroup name not found - AutoScalingGroup n0n3x1stentname27b not found' == output.msg"
-
-    - name: assert that the correct number of records are returned
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output.instance_refreshes | length == 7
-
-    - name: assert that valid message with fake-token is returned
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        next_token: "fake-token-123"
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - '"Failed to describe InstanceRefreshes: An error occurred (InvalidNextToken) when calling the DescribeInstanceRefreshes operation: The token ''********'' is invalid." == output.msg'
-
-    - name: assert that max records=1 returns no more than one record
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        max_records: 1
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output.instance_refreshes | length < 2
-
-    - name: assert that valid message with real-token is returned
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        next_token: "{{ output.next_token }}"
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output.instance_refreshes | length == 7
-
-    - name: test using both real nextToken and max_records=1
-      autoscaling_instance_refresh_info:
-        name: "{{ asg_name }}"
-        max_records: 1
-        next_token: "{{ output.next_token }}"
-      ignore_errors: yes
-      register: output
-
-    - assert:
-        that:
-          - output.instance_refreshes | length == 1
+    - name: Run test with instance_refresh_info.yml
+      include_tasks: instance_refresh_info.yml
 
   always:
 
-    - name: kill asg
+    - name: Kill asg
       autoscaling_group:
         name: "{{ asg_name }}"
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
     # Remove the testing dependencies
 
-    - name: remove the load balancer
+    - name: Remove the load balancer
       elb_classic_lb:
         name: "{{ load_balancer_name }}"
         state: absent
         security_group_ids:
           - "{{ sg.group_id }}"
         subnets: "{{ testing_subnet.subnet.id }}"
-        wait: yes
+        wait: true
         connection_draining_timeout: 60
         listeners:
           - protocol: http
@@ -436,22 +145,22 @@
             healthy_threshold: 2
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
-    - name: remove launch configs
+    - name: Remove launch configs
       autoscaling_launch_config:
         name: "{{ item }}"
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
       loop:
         - "{{ lc_name_1 }}"
         - "{{ lc_name_2 }}"
 
-    - name: delete launch template
+    - name: Delete launch template
       ec2_launch_template:
         name: "{{ resource_prefix }}-lt"
         state: absent
@@ -460,7 +169,7 @@
       until: del_lt is not failed
       ignore_errors: true
 
-    - name: remove the security group
+    - name: Remove the security group
       ec2_security_group:
         name: "{{ sg_name }}"
         description: a security group for ansible tests
@@ -468,10 +177,10 @@
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
-    - name: remove routing rules
+    - name: Remove routing rules
       ec2_vpc_route_table:
         state: absent
         vpc_id: "{{ testing_vpc.vpc.id }}"
@@ -484,34 +193,34 @@
           - "{{ testing_subnet.subnet.id }}"
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
-    - name: remove internet gateway
+    - name: Remove internet gateway
       ec2_vpc_igw:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
-    - name: remove the subnet
+    - name: Remove the subnet
       ec2_vpc_subnet:
         state: absent
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: '{{ subnet_a_cidr }}'
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
-    - name: remove the VPC
+    - name: Remove the VPC
       ec2_vpc_net:
         name: "{{ vpc_name }}"
         cidr_block: '{{ subnet_a_cidr }}'
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/refresh_and_cancel_three_times.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/refresh_and_cancel_three_times.yml
@@ -1,29 +1,14 @@
 ---
-
-- name: try to cancel pre-loop
-  autoscaling_instance_refresh:
-    name: "{{ asg_name }}"
-    state: "cancelled"
-  ignore_errors: yes
-
-- name: test starting a refresh with an ASG name
+- name: Test starting a refresh with an ASG name
   autoscaling_instance_refresh:
     name: "{{ asg_name }}"
     state: "started"
-    access_key: "{{ aws_access_key }}"
-    secret_key: "{{ aws_secret_key }}"
-    region: "{{ aws_region }}"
-  ignore_errors: no
   retries: 10
   delay: 5
   register: refreshout
   until: refreshout is not failed
 
-- name: test cancelling a refresh with an ASG name
+- name: Test cancelling a refresh with an ASG name
   autoscaling_instance_refresh:
     name: "{{ asg_name }}"
     state: "cancelled"
-    access_key: "{{ aws_access_key }}"
-    secret_key: "{{ aws_secret_key }}"
-    region: "{{ aws_region }}"
-  ignore_errors: yes

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
@@ -1,0 +1,206 @@
+---
+- name: test invalid cancelation - V1 - (pre-refresh)
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  ignore_errors: true
+  register: result
+
+- name: Assert that module failed with proper message
+  assert:
+    that:
+      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress or pending Instance Refresh found for Auto Scaling group ' ~ resource_prefix ~ '-asg' in result.msg"
+
+- name: Test starting a refresh with a valid ASG name - check_mode
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+  check_mode: true
+  register: output
+
+- name: Validate starting in check_mode
+  assert:
+    that:
+      - output is changed
+      - '"autoscaling:StartInstanceRefresh" not in output.resource_actions'
+
+- name: Test starting a refresh with a valid ASG name
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+  register: output
+
+- name: Validate start
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Test starting a refresh with a valid ASG name - Idempotent
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+  ignore_errors: true
+  register: output
+
+- name: Validate starting Idempotency
+  assert:
+    that:
+      - output is not changed
+      - '"Failed to start InstanceRefresh: An error occurred (InstanceRefreshInProgress) when calling the StartInstanceRefresh operation: An Instance Refresh is already in progress and blocks the execution of this Instance Refresh." in output.msg'
+
+- name: Test starting a refresh with a valid ASG name - Idempotent (check_mode)
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+  check_mode: true
+  register: output
+
+- name: Validate starting Idempotency in check_mode
+  assert:
+    that:
+      - output is not changed
+      - '"In check_mode - Instance Refresh is already in progress, can not start new instance refresh." in output.msg'
+
+- name: Test starting a refresh with a nonexistent ASG name
+  autoscaling_instance_refresh:
+    name: "nonexistentname-asg"
+    state: "started"
+  ignore_errors: true
+  register: result
+
+- name: Assert that module failed with proper message
+  assert:
+    that:
+      - "'Failed to start InstanceRefresh: An error occurred (ValidationError) when calling the StartInstanceRefresh operation: AutoScalingGroup name not found' in result.msg"
+
+- name: Test canceling a refresh with an ASG name - check_mode
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  check_mode: true
+  register: output
+
+- name: Validate cancelation
+  assert:
+    that:
+      - output is not failed
+      - output is changed
+      - '"autoscaling:CancelInstanceRefresh" not in output.resource_actions'
+
+- name: Test canceling a refresh with an ASG name
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  register: output
+
+- name: Validate cancelation
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Test canceling a refresh with a ASG name - Idempotent
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  register: output
+  ignore_errors: true
+
+- name: Validate cancelling Idempotency
+  assert:
+    that:
+      - output is not changed
+
+- name: Test cancelling a refresh with a valid ASG name - Idempotent (check_mode)
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  check_mode: true
+  register: output
+
+- name: Validate cancelling Idempotency in check_mode
+  assert:
+    that:
+      - output is not changed
+
+- name: Test starting a refresh with an ASG name and preferences dict
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+    preferences:
+      min_healthy_percentage: 10
+      instance_warmup: 10
+  retries: 5
+  register: output
+  until: output is not failed
+
+- name: Assert that module succeed with preferences
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Re-test canceling a refresh with an ASG name
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  register: output
+
+- name: Assert that module returned instance refresh id
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Test valid start - V1 - (with preferences missing instance_warmup)
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+    preferences:
+      min_healthy_percentage: 10
+  retries: 5
+  register: output
+  until: output is not failed
+
+- name: Validate start with preferences missing instance warmup
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Re-test canceling a refresh with an ASG name
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+  register: output
+
+- name: Validate canceling Idempotency
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Test valid start - V2 - (with preferences missing min_healthy_percentage)
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "started"
+    preferences:
+      instance_warmup: 10
+  retries: 5
+  register: output
+  until: output is not failed
+
+- name: Assert that module did not returned and instance refresh id
+  assert:
+    that:
+      - "'instance_refresh_id' in output.instance_refreshes"
+
+- name: Test invalid cancelation - V2 - (with preferences)
+  autoscaling_instance_refresh:
+    name: "{{ asg_name }}"
+    state: "cancelled"
+    preferences:
+      min_healthy_percentage: 10
+      instance_warmup: 10
+  ignore_errors: true
+  register: result
+
+- name: Assert that module failed with proper message
+  assert:
+    that:
+      - "'can not pass preferences dict when canceling a refresh' in result.msg"

--- a/tests/integration/targets/ec2_vpc_egress_igw/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_egress_igw/meta/main.yml
@@ -1,1 +1,0 @@
-dependencies: []

--- a/tests/integration/targets/ec2_vpc_egress_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_egress_igw/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
-- name: 'ec2_vpc_egress_igw integration tests'
-  collections:
-    - amazon.aws
+- name: Run ec2_vpc_egress_igw integration tests
   module_defaults:
     group/aws:
       access_key: '{{ aws_access_key }}'
@@ -11,35 +9,36 @@
   block:
 
   # ============================================================
-  - name: test failure with no parameters
-    ec2_vpc_egress_igw:
+  - name: Test failure with no parameters
+    community.aws.ec2_vpc_egress_igw:
     register: result
     ignore_errors: true
 
-  - name: assert failure with no parameters
-    assert:
+  - name: Assert failure with no parameters
+    ansible.builtin.assert:
       that:
-        - 'result.failed'
+        - result is failed
         - 'result.msg == "missing required arguments: vpc_id"'
 
   # ============================================================
-  - name: test failure with non-existent VPC ID
-    ec2_vpc_egress_igw:
+  - name: Test failure with non-existent VPC ID
+    community.aws.ec2_vpc_egress_igw:
       state: present
       vpc_id: vpc-02394e50abc1807e8
     register: result
     ignore_errors: true
 
-  - name: assert failure with non-existent VPC ID
-    assert:
+  - name: Assert failure with non-existent VPC ID
+    ansible.builtin.assert:
       that:
-        - 'result.failed'
-        - 'result.error.code == "InvalidVpcID.NotFound"'
-        - '"invalid vpc ID" in result.msg'
+        - result is failed
+        - e_msg in result.exception
+    vars:
+      e_msg: "The vpc ID 'vpc-02394e50abc1807e8' does not exist"
 
   # ============================================================
-  - name: create a VPC
-    ec2_vpc_net:
+  - name: Create a VPC
+    amazon.aws.ec2_vpc_net:
       name: "{{ resource_prefix }}-vpc"
       state: present
       cidr_block: "10.232.232.128/26"
@@ -49,55 +48,133 @@
     register: vpc_result
 
   # ============================================================
-  - name: create egress-only internet gateway (expected changed=true)
-    ec2_vpc_egress_igw:
+  - name: Create egress-only internet gateway using check_mode=true
+    community.aws.ec2_vpc_egress_igw:
+      state: present
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_eigw_create_check_mode
+    check_mode: true
+
+  - name: Assert module returned changed and the Egress IGW was not created
+    ansible.builtin.assert:
+      that:
+          - vpc_eigw_create_check_mode is changed
+
+  # # ============================================================
+  - name: Create egress-only internet gateway (expected changed=true)
+    community.aws.ec2_vpc_egress_igw:
       state: present
       vpc_id: "{{ vpc_result.vpc.id }}"
     register: vpc_eigw_create
 
-  - name: assert creation happened (expected changed=true)
-    assert:
+  - name: Assert module returned changed and the Egress IGW was not created
+    ansible.builtin.assert:
       that:
-          - 'vpc_eigw_create'
-          - 'vpc_eigw_create.gateway_id.startswith("eigw-")'
-          - 'vpc_eigw_create.vpc_id == vpc_result.vpc.id'
+          - vpc_eigw_create is changed
 
-  # ============================================================
-  - name: attempt to recreate egress-only internet gateway on VPC (expected changed=false)
-    ec2_vpc_egress_igw:
+  # # ============================================================
+  - name: Create egress-only internet gateway once again (idempotency)
+    community.aws.ec2_vpc_egress_igw:
       state: present
       vpc_id: "{{ vpc_result.vpc.id }}"
-    register: vpc_eigw_recreate
+    register: vpc_eigw_create_idempotency
 
-  - name: assert recreation did nothing (expected changed=false)
+  - name: Assert module returned changed and the Egress IGW was not created
     assert:
       that:
-          - 'vpc_eigw_recreate.changed == False'
-          - 'vpc_eigw_recreate.gateway_id == vpc_eigw_create.gateway_id'
-          - 'vpc_eigw_recreate.vpc_id == vpc_eigw_create.vpc_id'
+          - vpc_eigw_create_idempotency is not changed
+          - vpc_eigw_create_idempotency.gateway_id == vpc_eigw_create.gateway_id
 
-  # ============================================================
-  - name: test state=absent (expected changed=true)
+  # # ============================================================
+  - name: Delete egress-only internet gateway (check_mode)
     ec2_vpc_egress_igw:
+      state: absent
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_eigw_delete_check_mode
+    check_mode: true
+
+  - name: Assert module returned changed and the Egress IGW was not created
+    ansible.builtin.assert:
+      that:
+          - vpc_eigw_delete_check_mode is changed
+          - vpc_eigw_create_idempotency.gateway_id == vpc_eigw_delete_check_mode.gateway_id
+
+  # # ============================================================
+  - name: Delete egress-only internet gateway once again (idempotency)
+    community.aws.ec2_vpc_egress_igw:
       state: absent
       vpc_id: "{{ vpc_result.vpc.id }}"
     register: vpc_eigw_delete
 
-  - name: assert state=absent (expected changed=true)
-    assert:
+  - name: Assert module returned changed and the Egress IGW was not created
+    ansible.builtin.assert:
       that:
-          - 'vpc_eigw_delete.changed'
+        - vpc_eigw_delete is changed
+        - vpc_eigw_create_idempotency.gateway_id == vpc_eigw_delete.gateway_id
+
+  # # ============================================================
+  - name: Delete egress-only internet gateway
+    ec2_vpc_egress_igw:
+      state: absent
+      vpc_id: "{{ vpc_result.vpc.id }}"
+    register: vpc_eigw_delete_idempotency
+
+  - name: Assert module returned changed and the Egress IGW was not created
+    ansible.builtin.assert:
+      that:
+        - vpc_eigw_delete_idempotency is not changed
+
+  ## ============================================================
+  ## Tagging
+  - name: Create Egress only internet gateway with tags
+    community.aws.ec2_vpc_egress_igw:
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        ResourcePrefix: "{{ resource_prefix }}"
+        VpcId: "{{ vpc_result.vpc.id }}"
+    register: create_with_tags
+
+  - name: Assert that the Egress IGW was created with tags
+    ansible.builtin.assert:
+      that:
+        - create_with_tags is changed
+
+  - name: Trying to update tags (no change)
+    community.aws.ec2_vpc_egress_igw:
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        ResourcePrefix: "{{ resource_prefix }}"
+        VpcId: "{{ vpc_result.vpc.id }}"
+    register: update_tags
+
+  - name: Assert that the Egress IGW was not updated
+    ansible.builtin.assert:
+      that:
+        - update_tags is not changed
+
+  - name: Add tag to existing tags
+    community.aws.ec2_vpc_egress_igw:
+      vpc_id: "{{ vpc_result.vpc.id }}"
+      tags:
+        Phase: integration
+      purge_tags: false
+    register: add_tag
+
+  - name: Assert that the Egress IGW was created with tags
+    ansible.builtin.assert:
+      that:
+        - add_tag is changed
 
   always:
     # ============================================================
-    - name: tidy up EIGW
-      ec2_vpc_egress_igw:
+    - name: Tidy up EIGW
+      community.aws.ec2_vpc_egress_igw:
         state: absent
         vpc_id: "{{ vpc_result.vpc.id }}"
       ignore_errors: true
 
-    - name: tidy up VPC
-      ec2_vpc_net:
+    - name: Tidy up VPC
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         state: absent
         cidr_block: "10.232.232.128/26"

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,2 @@
+plugins/modules/ecs_cluster.py pylint:collection-deprecated-version
+plugins/modules/glue_connection.py pylint:collection-deprecated-version

--- a/tests/unit/plugins/modules/test_autoscaling_instance_refresh.py
+++ b/tests/unit/plugins/modules/test_autoscaling_instance_refresh.py
@@ -1,0 +1,28 @@
+# (c) 2024 Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+
+from ansible_collections.community.aws.plugins.modules.autoscaling_instance_refresh import validate_healthy_percentage
+
+
+@pytest.mark.parametrize(
+    "min_healthy, max_healthy, expected_error",
+    [
+        (90, None, None),
+        (-1, None, "The value range for the min_healthy_percentage is 0 to 100."),
+        (101, None, "The value range for the min_healthy_percentage is 0 to 100."),
+        (None, 90, "The value range for the max_healthy_percentage is 100 to 200."),
+        (None, 201, "The value range for the max_healthy_percentage is 100 to 200."),
+        (None, 100, "You must also specify min_healthy_percentage when max_healthy_percentage is specified."),
+        (10, 100, None),
+        (
+            10,
+            150,
+            "The difference between the max_healthy_percentage and min_healthy_percentage cannot be greater than 100.",
+        ),
+    ],
+)
+def test_validate_healthy_percentage(min_healthy, max_healthy, expected_error):
+    preferences = dict(min_healthy_percentage=min_healthy, max_healthy_percentage=max_healthy)
+    assert expected_error == validate_healthy_percentage(preferences)


### PR DESCRIPTION
- Remove modules ['ec2_vpc_egress_igw'] modules and tests
  These modules have been migrated to `amazon.aws`
- Update runtime.yml with redirects to that collection
- Update ignore files
